### PR TITLE
48 simplify the return type of incrsmallstrainmodelhistory dim

### DIFF
--- a/examples/linear_elasticity/test_elasticity.py
+++ b/examples/linear_elasticity/test_elasticity.py
@@ -16,7 +16,7 @@ poissons_ratio = 0.3
 
 
 def test_uniaxial_stress():
-    mesh = df.mesh.create_unit_interval(MPI.COMM_WORLD, 2)
+    mesh = df.mesh.create_unit_interval(MPI.COMM_WORLD, 4)
     V = df.fem.FunctionSpace(mesh, ("CG", 1))
     u = df.fem.Function(V)
     law = LinearElasticityModel(
@@ -41,18 +41,8 @@ def test_uniaxial_stress():
         u,
         [bc_left, bc_right],
     )
-    
-    df.log.set_log_level(df.log.LogLevel.INFO)
-    solver = NewtonSolver(MPI.COMM_WORLD, problem)
-    #ksp = solver.krylov_solver
-    #opts = PETSc.Options()
-    #print(opts.getAll())
-    #option_prefix = ksp.getOptionsPrefix()
-    #opts[f"{option_prefix}ksp_type"] = "gmres"
-    #opts[f"{option_prefix}pc_factor_mat_solver_type"] = "none"
-    #opts[f"{option_prefix}pc_type"] = "none"
 
-    #print(opts.getAll())
+    solver = NewtonSolver(MPI.COMM_WORLD, problem)
     n, converged = solver.solve(u)
 
     # Compare the result with the analytical solution
@@ -322,6 +312,7 @@ def test_3d():
     assert np.linalg.norm(u_fenics.x.array - u.x.array) < 1e-8 / np.linalg.norm(
         u_fenics.x.array
     )
+
 
 if __name__ == "__main__":
     test_uniaxial_stress()

--- a/examples/linear_elasticity/test_elasticity.py
+++ b/examples/linear_elasticity/test_elasticity.py
@@ -7,6 +7,7 @@ import ufl
 from dolfinx.nls.petsc import NewtonSolver
 from linear_elasticity_model import LinearElasticityModel
 from mpi4py import MPI
+from petsc4py import PETSc
 
 from fenics_constitutive import Constraint, IncrSmallStrainProblem
 
@@ -40,8 +41,18 @@ def test_uniaxial_stress():
         u,
         [bc_left, bc_right],
     )
-
+    
+    df.log.set_log_level(df.log.LogLevel.INFO)
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
+    #ksp = solver.krylov_solver
+    #opts = PETSc.Options()
+    #print(opts.getAll())
+    #option_prefix = ksp.getOptionsPrefix()
+    #opts[f"{option_prefix}ksp_type"] = "gmres"
+    #opts[f"{option_prefix}pc_factor_mat_solver_type"] = "none"
+    #opts[f"{option_prefix}pc_type"] = "none"
+
+    #print(opts.getAll())
     n, converged = solver.solve(u)
 
     # Compare the result with the analytical solution
@@ -311,3 +322,6 @@ def test_3d():
     assert np.linalg.norm(u_fenics.x.array - u.x.array) < 1e-8 / np.linalg.norm(
         u_fenics.x.array
     )
+
+if __name__ == "__main__":
+    test_uniaxial_stress()

--- a/examples/linear_elasticity/test_elasticity.py
+++ b/examples/linear_elasticity/test_elasticity.py
@@ -7,7 +7,6 @@ import ufl
 from dolfinx.nls.petsc import NewtonSolver
 from linear_elasticity_model import LinearElasticityModel
 from mpi4py import MPI
-from petsc4py import PETSc
 
 from fenics_constitutive import Constraint, IncrSmallStrainProblem
 
@@ -40,6 +39,7 @@ def test_uniaxial_stress():
         law,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -113,6 +113,7 @@ def test_uniaxial_stress_two_laws(factor: float):
         laws,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -155,6 +156,7 @@ def test_uniaxial_strain():
         law,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -197,6 +199,7 @@ def test_plane_strain():
         law,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -238,6 +241,7 @@ def test_plane_stress():
         law,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -279,6 +283,7 @@ def test_3d():
         law,
         u,
         [bc_left, bc_right],
+        1,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)

--- a/src/fenics_constitutive/interfaces.py
+++ b/src/fenics_constitutive/interfaces.py
@@ -133,7 +133,7 @@ class IncrSmallStrainModel(ABC):
         return self.constraint.geometric_dim()
 
     @abstractproperty
-    def history_dim(self) -> int | dict[str, int | tuple[int, int]] | None:
+    def history_dim(self) -> dict[str, int | tuple[int, int]] | None:
         """
         The dimensions of history variable(s). This is needed to tell the solver which quadrature
         spaces or arrays to build. If all history variables are stored in a single

--- a/src/fenics_constitutive/maps.py
+++ b/src/fenics_constitutive/maps.py
@@ -26,6 +26,7 @@ class SubSpaceMap:
     sub_mesh: df.mesh.Mesh
     parent_mesh: df.mesh.Mesh
 
+    @df.common.timed("constitutive: map_to_parent_mesh")
     def map_to_parent(self, sub: df.fem.Function, parent: df.fem.Function) -> None:
         """
         Map the values from the subspace to the parent space.
@@ -47,6 +48,7 @@ class SubSpaceMap:
         parent_array[self.parent] = sub_array[self.child]
         parent.x.scatter_forward()
 
+    @df.common.timed("constitutive: map_to_child_mesh")
     def map_to_child(self, parent: df.fem.Function, sub: df.fem.Function) -> None:
         """
         Map the values from the parent space to the subspace.
@@ -69,6 +71,7 @@ class SubSpaceMap:
         sub.x.scatter_forward()
 
 
+@df.common.timed("constitutive: build_subspace_map")
 def build_subspace_map(
     cells: np.ndarray, V: df.fem.FunctionSpace, return_subspace=False
 ) -> (
@@ -117,6 +120,6 @@ def build_subspace_map(
         )
     if return_subspace:
         return map, submesh, V_sub
-    else:
-        del V_sub
-        return map, submesh
+
+    del V_sub
+    return map, submesh

--- a/src/fenics_constitutive/solver.py
+++ b/src/fenics_constitutive/solver.py
@@ -13,7 +13,7 @@ from .stress_strain import ufl_mandel_strain
 
 def build_history(
     law: IncrSmallStrainModel, mesh: df.mesh.Mesh, q_degree: int
-) -> df.fem.Function | dict[str, df.fem.Function] | None:
+) -> dict[str, df.fem.Function] | None:
     """Build the history space and function(s) for the given law.
 
     Args:
@@ -25,40 +25,30 @@ def build_history(
         The history function(s) for the given law.
 
     """
-    match law.history_dim:
-        case int():
-            Qh = ufl.VectorElement(
-                "Quadrature",
-                mesh.ufl_cell(),
-                q_degree,
-                quad_scheme="default",
-                dim=law.history_dim,
-            )
-            history_space = df.fem.FunctionSpace(mesh, Qh)
-            history = df.fem.Function(history_space)
-        case None:
-            history = None
-        case dict():
-            history = {}
-            for key, value in law.history_dim.items():
-                if isinstance(value, int):
-                    Qh = ufl.VectorElement(
-                        "Quadrature",
-                        mesh.ufl_cell(),
-                        q_degree,
-                        quad_scheme="default",
-                        dim=value,
-                    )
-                elif isinstance(value, tuple):
-                    Qh = ufl.TensorElement(
-                        "Quadrature",
-                        mesh.ufl_cell(),
-                        q_degree,
-                        quad_scheme="default",
-                        shape=value,
-                    )
-                history_space = df.fem.FunctionSpace(mesh, Qh)
-                history[key] = df.fem.Function(history_space)
+    if law.history_dim is None:
+        return None
+
+    history = {}
+    for key, value in law.history_dim.items():
+        match value:
+            case int():
+                Qh = ufl.VectorElement(
+                    "Quadrature",
+                    mesh.ufl_cell(),
+                    q_degree,
+                    quad_scheme="default",
+                    dim=value,
+                )
+            case tuple():
+                Qh = ufl.TensorElement(
+                    "Quadrature",
+                    mesh.ufl_cell(),
+                    q_degree,
+                    quad_scheme="default",
+                    shape=value,
+                )
+        history_space = df.fem.FunctionSpace(mesh, Qh)
+        history[key] = df.fem.Function(history_space)
     return history
 
 
@@ -146,45 +136,27 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
 
         self._time = 0.0  # time at the end of the increment
 
-        with df.common.Timer("submeshes-and-data-structures"):
-            if len(laws) > 1:
-                for law, cells in laws:
-                    self.laws.append((law, cells))
-
-                    # ### submesh and subspace for strain, stress
-                    subspace_map, submesh, QV_subspace = build_subspace_map(
-                        cells, QV, return_subspace=True
-                    )
-                    self.submesh_maps.append(subspace_map)
-                    self._stress.append(df.fem.Function(QV_subspace))
-
-                    # subspace for grad u
-                    Q_grad_u_subspace = df.fem.FunctionSpace(submesh, Q_grad_u_e)
-                    self._del_grad_u.append(df.fem.Function(Q_grad_u_subspace))
-
-                    # subspace for tanget
-                    QT_subspace = df.fem.FunctionSpace(submesh, QTe)
-                    self._tangent.append(df.fem.Function(QT_subspace))
-
-                    # subspaces for history
-                    history_0 = build_history(law, submesh, q_degree)
-                    history_1 = (
-                        {key: fn.copy() for key, fn in history_0.items()}
-                        if isinstance(history_0, dict)
-                        else history_0
-                    )
-                    self._history_0.append(history_0)
-                    self._history_1.append(history_1)
-            else:
-                law, cells = laws[0]
+        if len(laws) > 1:
+            for law, cells in laws:
                 self.laws.append((law, cells))
 
-                # subspace for grad u
-                Q_grad_u_space = df.fem.FunctionSpace(mesh, Q_grad_u_e)
-                self._del_grad_u.append(df.fem.Function(Q_grad_u_space))
+                # ### submesh and subspace for strain, stress
+                subspace_map, submesh, QV_subspace = build_subspace_map(
+                    cells, QV, return_subspace=True
+                )
+                self.submesh_maps.append(subspace_map)
+                self._stress.append(df.fem.Function(QV_subspace))
 
-                # Spaces for history
-                history_0 = build_history(law, mesh, q_degree)
+                # subspace for grad u
+                Q_grad_u_subspace = df.fem.FunctionSpace(submesh, Q_grad_u_e)
+                self._del_grad_u.append(df.fem.Function(Q_grad_u_subspace))
+
+                # subspace for tanget
+                QT_subspace = df.fem.FunctionSpace(submesh, QTe)
+                self._tangent.append(df.fem.Function(QT_subspace))
+
+                # subspaces for history
+                history_0 = build_history(law, submesh, q_degree)
                 history_1 = (
                     {key: fn.copy() for key, fn in history_0.items()}
                     if isinstance(history_0, dict)
@@ -192,6 +164,23 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
                 )
                 self._history_0.append(history_0)
                 self._history_1.append(history_1)
+        else:
+            law, cells = laws[0]
+            self.laws.append((law, cells))
+
+            # subspace for grad u
+            Q_grad_u_space = df.fem.FunctionSpace(mesh, Q_grad_u_e)
+            self._del_grad_u.append(df.fem.Function(Q_grad_u_space))
+
+            # Spaces for history
+            history_0 = build_history(law, mesh, q_degree)
+            history_1 = (
+                {key: fn.copy() for key, fn in history_0.items()}
+                if history_0 is not None
+                else None
+            )
+            self._history_0.append(history_0)
+            self._history_1.append(history_1)
 
         self.stress_0 = df.fem.Function(QV)
         self.stress_1 = df.fem.Function(QV)
@@ -255,53 +244,57 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
 
         """
         super().form(x)
-
         assert (
             x.array.data == self._u.vector.array.data
         ), "The solution vector must be the same as the one passed to the MechanicsProblem"
+
         if len(self.laws) > 1:
             for k, (law, cells) in enumerate(self.laws):
-                with df.common.Timer("strain_evaluation"):
-                    # TODO: test this!!
-                    self.del_grad_u_expr.eval(
-                        cells, self._del_grad_u[k].x.array.reshape(cells.size, -1)
-                    )
-
-                with df.common.Timer("stress_evaluation"):
-                    self.submesh_maps[k].map_to_child(self.stress_0, self._stress[k])
-                    if law.history_dim is not None:
-                        self._history_1[0].x.array[:] = self._history_0[0].x.array
-                    law.evaluate(
-                        self._time,
-                        self._del_grad_u[k].x.array,
-                        self._stress[k].x.array,
-                        self._tangent[k].x.array,
-                        self._history_1[k].x.array
-                        if law.history_dim is not None
-                        else None,
-                    )
-
-                with df.common.Timer("stress-local-to-global"):
-                    self.submesh_maps[k].map_to_parent(self._stress[k], self.stress_1)
-                    self.submesh_maps[k].map_to_parent(self._tangent[k], self.tangent)
-        else:
-            law, cells = self.laws[0]
-            with df.common.Timer("strain_evaluation"):
+                # TODO: test this!
+                # Replace with `self._del_grad_u[k].interpolate(...)` in 0.8.0
                 self.del_grad_u_expr.eval(
-                    cells, self._del_grad_u[0].x.array.reshape(cells.size, -1)
+                    cells, self._del_grad_u[k].x.array.reshape(cells.size, -1)
                 )
 
-            with df.common.Timer("stress_evaluation"):
-                self.stress_1.x.array[:] = self.stress_0.x.array
+                self.submesh_maps[k].map_to_child(self.stress_0, self._stress[k])
+                history_input = None
                 if law.history_dim is not None:
-                    self._history_1[0].x.array[:] = self._history_0[0].x.array
+                    history_input = {}
+                    for key in law.history_dim:
+                        self._history_1[k][key].x.array[:] = self._history_0[k][
+                            key
+                        ].x.array
+                        history_input[key] = self._history_1[k][key].x.array
                 law.evaluate(
                     self._time,
-                    self._del_grad_u[0].x.array,
-                    self.stress_1.x.array,
-                    self.tangent.x.array,
-                    self._history_1[0].x.array if law.history_dim is not None else None,
+                    self._del_grad_u[k].x.array,
+                    self._stress[k].x.array,
+                    self._tangent[k].x.array,
+                    history_input,
                 )
+
+                self.submesh_maps[k].map_to_parent(self._stress[k], self.stress_1)
+                self.submesh_maps[k].map_to_parent(self._tangent[k], self.tangent)
+        else:
+            law, cells = self.laws[0]
+            self.del_grad_u_expr.eval(
+                cells, self._del_grad_u[0].x.array.reshape(cells.size, -1)
+            )
+
+            self.stress_1.x.array[:] = self.stress_0.x.array
+            history_input = None
+            if law.history_dim is not None:
+                history_input = {}
+                for key in law.history_dim:
+                    self._history_1[0][key].x.array[:] = self._history_0[0][key].x.array
+                    history_input[key] = self._history_1[0][key].x.array
+            law.evaluate(
+                self._time,
+                self._del_grad_u[0].x.array,
+                self.stress_1.x.array,
+                self.tangent.x.array,
+                history_input,
+            )
 
         self.stress_1.x.scatter_forward()
         self.tangent.x.scatter_forward()
@@ -317,15 +310,7 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
         self.stress_0.x.scatter_forward()
 
         for k, (law, _) in enumerate(self.laws):
-            match law.history_dim:
-                case int():
-                    self._history_0[k].x.array[:] = self._history_1[k].x.array
-                    self._history_0[k].x.scatter_forward()
-                case None:
-                    pass
-                case dict():
-                    for key in law.history_dim:
-                        self._history_0[k][key].x.array[:] = self._history_1[k][
-                            key
-                        ].x.array
-                        self._history_0[k][key].x.scatter_forward()
+            if law.history_dim is not None:
+                for key in law.history_dim:
+                    self._history_0[k][key].x.array[:] = self._history_1[k][key].x.array
+                    self._history_0[k][key].x.scatter_forward()

--- a/src/fenics_constitutive/solver.py
+++ b/src/fenics_constitutive/solver.py
@@ -80,7 +80,7 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
         laws: list[tuple[IncrSmallStrainModel, np.ndarray]] | IncrSmallStrainModel,
         u: df.fem.Function,
         bcs: list[df.fem.DirichletBCMetaClass],
-        q_degree: int = 1,
+        q_degree: int,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
     ):

--- a/src/fenics_constitutive/solver.py
+++ b/src/fenics_constitutive/solver.py
@@ -230,7 +230,7 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
             x: The vector containing the latest solution
 
         """
-        super().form(x)
+        #super().form(x)
         assert (
             x.array.data == self._u.vector.array.data
         ), "The solution vector must be the same as the one passed to the MechanicsProblem"
@@ -242,6 +242,7 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
             self.del_grad_u_expr.eval(
                 cells, self._del_grad_u[k].x.array.reshape(cells.size, -1)
             )
+            self._del_grad_u[k].x.scatter_forward()
             if len(self.laws) > 1:
                 self.submesh_maps[k].map_to_child(self.stress_0, self._stress[k])
                 stress_input = self._stress[k].x.array
@@ -268,6 +269,8 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
                 self.submesh_maps[k].map_to_parent(self._stress[k], self.stress_1)
                 self.submesh_maps[k].map_to_parent(self._tangent[k], self.tangent)
 
+        self.stress_1.x.scatter_forward()
+        self.tangent.x.scatter_forward()
         # else:
         #     law, cells = self.laws[0]
         #     self.del_grad_u_expr.eval(
@@ -289,8 +292,6 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
         #         history_input,
         #     )
 
-        self.stress_1.x.scatter_forward()
-        self.tangent.x.scatter_forward()
 
     def update(self) -> None:
         """


### PR DESCRIPTION
Just some refactoring of the solver and making the return type of `history_dim` easier to handle

Edit: Also made the `q_degree` parameter in the `IncrSmallStrainModel` not optional, since this can be a source of error that just makes PETSc crash without a good error message. 