### PR TITLE
57 using 3d models for uniaxial strain and palne strain

### DIFF
--- a/src/fenics_constitutive/solver.py
+++ b/src/fenics_constitutive/solver.py
@@ -220,6 +220,7 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
         self.q_points, _ = basix.make_quadrature(basix_celltype, q_degree)
 
         if as_3d:
+
             def grad(v):
                 return as_3d_tensor(ufl.nabla_grad(v), solver_constraint)
         else:
@@ -286,15 +287,15 @@ class IncrSmallStrainProblem(df.fem.petsc.NonlinearProblem):
                 for key in law.history_dim:
                     self._history_1[k][key].x.array[:] = self._history_0[k][key].x.array
                     history_input[key] = self._history_1[k][key].x.array
-
-            law.evaluate(
-                self._time,
-                self._del_t,
-                self._del_grad_u[k].x.array,
-                stress_input,
-                tangent_input,
-                history_input,
-            )
+            with df.common.Timer("constitutive-law-evaluation"):
+                law.evaluate(
+                    self._time,
+                    self._del_t,
+                    self._del_grad_u[k].x.array,
+                    stress_input,
+                    tangent_input,
+                    history_input,
+                )
             if len(self.laws) > 1:
                 self.submesh_maps[k].map_to_parent(self._stress[k], self.stress_1)
                 self.submesh_maps[k].map_to_parent(self._tangent[k], self.tangent)

--- a/src/fenics_constitutive/solver.py
+++ b/src/fenics_constitutive/solver.py
@@ -8,7 +8,7 @@ from petsc4py import PETSc
 
 from .interfaces import Constraint, IncrSmallStrainModel
 from .maps import SubSpaceMap, build_subspace_map
-from .stress_strain import as_3d_mandel, as_3d_tensor, ufl_mandel_strain
+from .stress_strain import as_3d_tensor, ufl_mandel_strain
 
 
 def build_history(

--- a/src/fenics_constitutive/stress_strain.py
+++ b/src/fenics_constitutive/stress_strain.py
@@ -5,7 +5,7 @@ import ufl
 
 from .interfaces import Constraint
 
-__all__ = ["ufl_mandel_strain", "strain_from_grad_u", "as_3d_mandel", "as_3d_tensor"]
+__all__ = ["ufl_mandel_strain", "strain_from_grad_u", "as_3d_tensor"]
 
 
 def ufl_mandel_strain(
@@ -160,22 +160,6 @@ def strain_from_grad_u(grad_u: np.ndarray, constraint: Constraint) -> np.ndarray
     return strain
 
 
-def as_3d_mandel(
-    strain: ufl.core.expr.Expr, constraint: Constraint
-) -> ufl.core.expr.Expr:
-    """
-    Convert a not 3D Mandel strain to a 3D Mandel strain.
-    """
-    match constraint:
-        case Constraint.UNIAXIAL_STRAIN:
-            return ufl.as_vector([strain, 0.0, 0.0, 0.0, 0.0, 0.0])
-        case Constraint.PLANE_STRAIN:
-            return ufl.as_vector([strain[0], strain[1], strain[2], strain[3], 0.0, 0.0])
-        case _:
-            msg = f"Cannot convert {constraint} to 3D Mandel strain."
-            raise NotImplementedError(msg)
-
-
 def as_3d_tensor(
     tensor: ufl.core.expr.Expr, constraint: Constraint
 ) -> ufl.core.expr.Expr:
@@ -184,7 +168,9 @@ def as_3d_tensor(
     """
     match constraint:
         case Constraint.UNIAXIAL_STRAIN:
-            return ufl.as_matrix([[tensor, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+            return ufl.as_matrix(
+                [[tensor[0], 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+            )
         case Constraint.PLANE_STRAIN:
             return ufl.as_matrix(
                 [


### PR DESCRIPTION
This adds a new parameter `solver_constraint` to the `IncrSmallstrainProblem`. If it is set, then the solver works with the prescribed constraint but with 3d models. `grad_del_u` is transformed to 3d and also the mandel strains in the weak forms are transformed to the 3D case. If the parameter is not set, then the solver constraint is assumed from the material laws.

This means that we can simulate uniaxial strain and plane strain with models that have been implemented for 3D.