### PR TITLE
Try new version of mabaforge plugin in github workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
             miniforge-variant: Mambaforge
             miniforge-version: latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
-            miniforge-variant: Mambaforge
+            #miniforge-variant: Mambaforge
             miniforge-version: latest
             activate-environment: fenics-constitutive
             use-mamba: true


### PR DESCRIPTION
Our tests keep failing. It never gets past the setup of mamba, therefore, I want to try the newes version of https://github.com/conda-incubator/setup-miniconda