### PR TITLE
74 find a nicer way to include neumann bcs and body forces

### DIFF
--- a/src/fenics_constitutive/solver/_solver.py
+++ b/src/fenics_constitutive/solver/_solver.py
@@ -57,6 +57,7 @@ class IncrSmallStrainProblem(NonlinearProblem):
         u: df.fem.Function,
         bcs: list[df.fem.DirichletBC],
         q_degree: int,
+        external_forces: list[ufl.Form] | None = None,
         del_t: float = 1.0,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
@@ -92,6 +93,10 @@ class IncrSmallStrainProblem(NonlinearProblem):
         self.R_form = (
             ufl.inner(ufl_mandel_strain(u_, constraint), self.stress.current) * self.dxm
         )
+        
+        if external_forces is not None:
+            self.R_form -= sum(external_forces)
+        
         self.dR_form = (
             ufl.inner(
                 ufl_mandel_strain(du, constraint),

--- a/src/fenics_constitutive/solver/_solver.py
+++ b/src/fenics_constitutive/solver/_solver.py
@@ -90,14 +90,14 @@ class IncrSmallStrainProblem(NonlinearProblem):
         self.metadata = {"quadrature_degree": q_degree, "quadrature_scheme": "default"}
         self.dxm = ufl.dx(metadata=self.metadata)
 
-        self.R_form = (
+        R_form = (
             ufl.inner(ufl_mandel_strain(u_, constraint), self.stress.current) * self.dxm
         )
         
         if external_forces is not None:
-            self.R_form -= sum(external_forces)
+            R_form -= sum(external_forces)
         
-        self.dR_form = (
+        dR_form = (
             ufl.inner(
                 ufl_mandel_strain(du, constraint),
                 ufl.dot(self.tangent, ufl_mandel_strain(u_, constraint)),
@@ -105,16 +105,12 @@ class IncrSmallStrainProblem(NonlinearProblem):
             * self.dxm
         )
 
-        self._bcs = bcs
-        self._form_compiler_options = form_compiler_options
-        self._jit_options = jit_options
-
         self.incr_disp = IncrementalDisplacement(u, q_degree)
         super().__init__(
-                self.R_form,
+                R_form,
                 self.incr_disp.current,
-                bcs=self._bcs,
-                J=self.dR_form,
+                bcs=bcs,
+                J=dR_form,
                 form_compiler_options=form_compiler_options if form_compiler_options is not None else {},
                 jit_options=jit_options if jit_options is not None else {}
             )

--- a/src/fenics_constitutive/solver/_solver.py
+++ b/src/fenics_constitutive/solver/_solver.py
@@ -57,8 +57,8 @@ class IncrSmallStrainProblem(NonlinearProblem):
         u: df.fem.Function,
         bcs: list[df.fem.DirichletBC],
         q_degree: int,
-        external_forces: list[ufl.Form] | None = None,
         del_t: float = 1.0,
+        external_forces: list[ufl.Form] | None = None,
         form_compiler_options: dict | None = None,
         jit_options: dict | None = None,
     ) -> None:

--- a/src/fenics_constitutive/solver/_solver.py
+++ b/src/fenics_constitutive/solver/_solver.py
@@ -110,27 +110,14 @@ class IncrSmallStrainProblem(NonlinearProblem):
         self._jit_options = jit_options
 
         self.incr_disp = IncrementalDisplacement(u, q_degree)
-
-    @property
-    def a(self) -> df.fem.Form:
-        """Compiled bilinear form (the Jacobian form)"""
-
-        if not hasattr(self, "_a"):
-            # ensure compilation of UFL forms
-            super().__init__(
+        super().__init__(
                 self.R_form,
                 self.incr_disp.current,
-                self._bcs,
-                self.dR_form,
-                form_compiler_options=(
-                    self._form_compiler_options
-                    if self._form_compiler_options is not None
-                    else {}
-                ),
-                jit_options=self._jit_options if self._jit_options is not None else {},
+                bcs=self._bcs,
+                J=self.dR_form,
+                form_compiler_options=form_compiler_options if form_compiler_options is not None else {},
+                jit_options=jit_options if jit_options is not None else {}
             )
-
-        return self._a
 
     @df.common.timed("constitutive-form-evaluation")
     def form(self, x: PETSc.Vec) -> None:

--- a/tests/models/test_viscoelasticity.py
+++ b/tests/models/test_viscoelasticity.py
@@ -452,6 +452,10 @@ def test_creep(dim: int, mat: IncrSmallStrainModel):
     facet_tags, _ = create_meshtags(mesh, mesh.topology.dim - 1, neumann_boundary)
     dA = ufl.Measure("ds", domain=mesh, subdomain_data=facet_tags)
     neumann_data = df.fem.Constant(mesh, load)
+    
+    # apply load
+    test_function = ufl.TestFunction(V)
+    fext = ufl.inner(neumann_data, test_function) * dA(neumann_tag)
 
     # problem and solve
     dt = 2
@@ -461,11 +465,8 @@ def test_creep(dim: int, mat: IncrSmallStrainModel):
         dirc_bcs,
         1,
         del_t=dt,
+        external_forces=[fext],
     )
-    # apply load
-    test_function = ufl.TestFunction(V)
-    fext = ufl.inner(neumann_data, test_function) * dA(neumann_tag)
-    problem.R_form -= fext
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
 

--- a/tests/models/test_viscoelasticity.py
+++ b/tests/models/test_viscoelasticity.py
@@ -53,7 +53,7 @@ def test_relaxation_uniaxial_stress(mat: IncrSmallStrainModel):
         u,
         [bc_left, bc_right],
         1,
-        dt,
+        del_t=dt,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -219,7 +219,7 @@ def test_relaxation(dim: int, mat: IncrSmallStrainModel):
         u,
         dirc_bcs,
         1,
-        dt,
+        del_t=dt,
     )
 
     solver = NewtonSolver(MPI.COMM_WORLD, problem)
@@ -331,8 +331,8 @@ def test_kelvin_vs_maxwell():
     # solve Kelvin problem without linear step
     dt, q_degree = 0.1, 4
     problems = [
-        IncrSmallStrainProblem(law_K, u, [bc_left, bc_right], q_degree, dt),
-        IncrSmallStrainProblem(law_M, u, [bc_left, bc_right], q_degree, dt),
+        IncrSmallStrainProblem(law_K, u, [bc_left, bc_right], q_degree, del_t=dt),
+        IncrSmallStrainProblem(law_M, u, [bc_left, bc_right], q_degree, del_t=dt),
     ]
 
     stress_p, strain_p = [], []
@@ -460,7 +460,7 @@ def test_creep(dim: int, mat: IncrSmallStrainModel):
         u,
         dirc_bcs,
         1,
-        dt,
+        del_t=dt,
     )
     # apply load
     test_function = ufl.TestFunction(V)
@@ -657,7 +657,7 @@ def define_problem(mat: IncrSmallStrainModel, dim: int):
 
     # problem
     dt = 5
-    problem = IncrSmallStrainProblem(law, u, bc_list, 1, dt)
+    problem = IncrSmallStrainProblem(law, u, bc_list, 1, del_t=dt)
     return u, problem
 
 


### PR DESCRIPTION
Neumann bcs as parameter `external_forces` in the `IncrSmallStrainProblem`. This is tested in the test for the viscoelastic models where the `test_creep` uses a Neumann BC and compares it to an analytical solution.